### PR TITLE
Ft/redis cache

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,23 @@
+version: '2'
+services:
+
+  redis:
+    image: redis
+    restart: always
+    ports:
+      - "6379:6379"
+
+  app:
+    image: "node:9"
+    depends_on:
+      - redis
+    working_dir: /home/node/app
+    environment:
+      - NODE_ENV=development
+    volumes:
+      - ./:/home/node/app
+    ports:
+      - "3000:3000"
+    command: "yarn run dev"
+    links:
+      - redis

--- a/package.json
+++ b/package.json
@@ -15,8 +15,10 @@
     "ejs": "^2.6.1",
     "express": "^4.16.3",
     "express-promise": "^0.4.0",
+    "ioredis": "^4.0.0",
     "lodash": "^4.17.11",
     "node-yaml-config": "^0.0.4",
+    "redis": "^2.8.0",
     "winston": "^3.1.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Instead of looking up each product by its ASIN from scratch, we can cache the results in Redis. 

This dramatically speeds up look ups of ASIN's which we've already done.